### PR TITLE
Passes the context to plugins

### DIFF
--- a/src/api-gateway.js
+++ b/src/api-gateway.js
@@ -47,7 +47,7 @@ function ApiGateway (options) {
 
           Object.getOwnPropertyNames(pluginsForHook)
             .forEach(pluginName => {
-              pluginsForHook[pluginName](options[pluginName] || null)(requestEvent, responseObject, error)
+              pluginsForHook[pluginName](options[pluginName] || null)(requestEvent, responseObject, error, context)
             })
         })
 


### PR DESCRIPTION
Passes the Lambda `context` object to plugins to allow them to make changes to its properties.

This is required in certain applications, such as stopping the callback waiting for an empty event 
loop  when dealing with connection pools.