### PR TITLE
Pass the context through to the lambda handler when using @Handler annotation.

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -10,8 +10,8 @@ function Handler (options) {
     descriptor.value = function (event, context, callback) {
       const requestEvent = JSON.parse(JSON.stringify(event))
 
-      Promise.resolve(requestEvent)
-        .then(e => fn.apply(this, [e]))
+      Promise.resolve([requestEvent, context])
+        .then(([e, c]) => fn.apply(this, [e, c]))
         .then(
           res => callback(null, res),
           err => callback(err)


### PR DESCRIPTION
Currently, the @Handler annotation does not use the use the plugin
architecture used by the @APIGateway annotation, but we still need to be
able to adjust properties on the context.

For the time being, we will thus pass the context through to the
handler.