### PR TITLE
Custom error response documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ vary: accept-encoding
 ## Specifying a custom error response
 
 ```javascript
+import { Plugins } from 'lambda-lib'
 
 // Registering a custom error response plugin. This is applied globally.
-ApiGateway.registerPlugin(new ErrorResponsePlugin(err => {
+ApiGateway.registerPlugin(new Plugins.ErrorResponse(err => {
   return {
     test: 'This is the error response body for all errors',
     error: err.message


### PR DESCRIPTION
The documentation doesn't include the method for importing the `ErrorResponse` plugin. It also references the classname incorrectly.